### PR TITLE
chore: modernize 4 packages to net8.0, EF Core 8, SourceLink, CI/CD/Sonar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.yml text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: 8.0.x
       - name: Restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore
+        run: |
+          dotnet restore Stocks.Data.Model/Stocks.Data.Model.csproj
+          dotnet restore Stocks.Data.Common/Stocks.Data.Common.csproj
+          dotnet restore Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj
+          dotnet restore Stocks.Data.Ef/Stocks.Data.Ef.csproj
+          dotnet restore Stocks.Data.Ado/Stocks.Data.Ado.csproj
+          dotnet restore Stocks.Data.UnitTests.Model/Stocks.Data.UnitTests.Model.csproj
+          dotnet restore Stocks.Data.UnitTests.Infrastructure/Stocks.Data.UnitTests.Common.csproj
+          dotnet restore Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj
+      - name: Build
+        run: |
+          dotnet build Stocks.Data.Model/Stocks.Data.Model.csproj --no-restore
+          dotnet build Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj --no-restore
+          dotnet build Stocks.Data.Ef/Stocks.Data.Ef.csproj --no-restore
+          dotnet build Stocks.Data.Ado/Stocks.Data.Ado.csproj --no-restore
+      - name: Test
+        run: |
+          dotnet test Stocks.Data.UnitTests.Model/Stocks.Data.UnitTests.Model.csproj --no-build --verbosity normal
+          dotnet test Stocks.Data.UnitTests.Infrastructure/Stocks.Data.UnitTests.Common.csproj --no-build --verbosity normal
+          dotnet test Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj --no-build --verbosity normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,9 @@ jobs:
           dotnet restore Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj
       - name: Build
         run: |
-          dotnet build Stocks.Data.Model/Stocks.Data.Model.csproj --no-restore
-          dotnet build Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj --no-restore
-          dotnet build Stocks.Data.Ef/Stocks.Data.Ef.csproj --no-restore
-          dotnet build Stocks.Data.Ado/Stocks.Data.Ado.csproj --no-restore
+          dotnet build Stocks.Data.UnitTests.Model/Stocks.Data.UnitTests.Model.csproj --no-restore
+          dotnet build Stocks.Data.UnitTests.Infrastructure/Stocks.Data.UnitTests.Common.csproj --no-restore
+          dotnet build Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj --no-restore
       - name: Test
         run: |
           dotnet test Stocks.Data.UnitTests.Model/Stocks.Data.UnitTests.Model.csproj --no-build --verbosity normal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore and Build
+        run: |
+          dotnet restore Stocks.Data.Model/Stocks.Data.Model.csproj
+          dotnet restore Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj
+          dotnet restore Stocks.Data.Ef/Stocks.Data.Ef.csproj
+          dotnet restore Stocks.Data.Ado/Stocks.Data.Ado.csproj
+          dotnet build Stocks.Data.Model/Stocks.Data.Model.csproj --no-restore -c Release
+          dotnet build Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj --no-restore -c Release
+          dotnet build Stocks.Data.Ef/Stocks.Data.Ef.csproj --no-restore -c Release
+          dotnet build Stocks.Data.Ado/Stocks.Data.Ado.csproj --no-restore -c Release
+      - name: Pack
+        run: |
+          dotnet pack Stocks.Data.Model/Stocks.Data.Model.csproj --no-build -c Release -o nupkgs
+          dotnet pack Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj --no-build -c Release -o nupkgs
+          dotnet pack Stocks.Data.Ef/Stocks.Data.Ef.csproj --no-build -c Release -o nupkgs
+          dotnet pack Stocks.Data.Ado/Stocks.Data.Ado.csproj --no-build -c Release -o nupkgs
+      - name: Login to NuGet
+        uses: NuGet/login@v1
+        with:
+          usernameVar: NUGET_USER
+          tokenVar: NUGET_TOKEN
+      - name: Push to NuGet
+        run: dotnet nuget push nupkgs/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: 8.0.x
       - name: Restore and Build
@@ -34,7 +34,7 @@ jobs:
           dotnet pack Stocks.Data.Ef/Stocks.Data.Ef.csproj --no-build -c Release -o nupkgs
           dotnet pack Stocks.Data.Ado/Stocks.Data.Ado.csproj --no-build -c Release -o nupkgs
       - name: Login to NuGet
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1
         with:
           usernameVar: NUGET_USER
           tokenVar: NUGET_TOKEN

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,20 +10,20 @@ jobs:
   sonar:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5
         with:
           dotnet-version: 8.0.x
       - name: Setup Java (required by SonarScanner)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: temurin
           java-version: 21
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,54 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+      - name: Setup Java (required by SonarScanner)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+      - name: Install dotnet-sonarscanner
+        run: dotnet tool install --global dotnet-sonarscanner
+      - name: Install dotnet-coverage
+        run: dotnet tool install --global dotnet-coverage
+      - name: SonarCloud begin
+        run: |
+          dotnet sonarscanner begin \
+            /k:"PFalkowski_StocksData" \
+            /o:"pfalkowski" \
+            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+      - name: Build
+        run: |
+          dotnet build Stocks.Data.Model/Stocks.Data.Model.csproj --no-incremental
+          dotnet build Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj --no-incremental
+          dotnet build Stocks.Data.Ef/Stocks.Data.Ef.csproj --no-incremental
+          dotnet build Stocks.Data.Ado/Stocks.Data.Ado.csproj --no-incremental
+      - name: Collect coverage
+        run: |
+          dotnet-coverage collect "dotnet test Stocks.Data.UnitTests.Model/Stocks.Data.UnitTests.Model.csproj --no-build" -f xml -o coverage_model.xml
+          dotnet-coverage collect "dotnet test Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj --no-build" -f xml -o coverage_ef.xml
+          dotnet-coverage merge coverage_model.xml coverage_ef.xml -f xml -o coverage.xml
+      - name: SonarCloud end
+        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Install dotnet-coverage
         run: dotnet tool install --global dotnet-coverage
       - name: SonarCloud begin
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           dotnet sonarscanner begin \
             /k:"PFalkowski_StocksData" \
@@ -51,4 +53,6 @@ jobs:
           dotnet-coverage collect "dotnet test Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj --no-build" -f xml -o coverage_ef.xml
           dotnet-coverage merge coverage_model.xml coverage_ef.xml -f xml -o coverage.xml
       - name: SonarCloud end
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,7 +36,7 @@ jobs:
           dotnet sonarscanner begin \
             /k:"PFalkowski_StocksData" \
             /o:"pfalkowski" \
-            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.token="$SONAR_TOKEN" \
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
       - name: Build
@@ -51,4 +51,4 @@ jobs:
           dotnet-coverage collect "dotnet test Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj --no-build" -f xml -o coverage_ef.xml
           dotnet-coverage merge coverage_model.xml coverage_ef.xml -f xml -o coverage.xml
       - name: SonarCloud end
-        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        run: dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# Stocks.Data.TradingSimulator
+# StocksData
 
-A .NET Standard 2.1 library for simulating stock trading strategies using historical market data.
+[![CI](https://github.com/PFalkowski/StocksData/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/StocksData/actions/workflows/ci.yml)
+[![NuGet (Model)](https://img.shields.io/nuget/v/Stocks.Data.Model.svg?label=Model)](https://www.nuget.org/packages/Stocks.Data.Model/)
+[![NuGet (Infrastructure)](https://img.shields.io/nuget/v/Stocks.Data.Infrastructure.svg?label=Infrastructure)](https://www.nuget.org/packages/Stocks.Data.Infrastructure/)
+[![NuGet (Ef)](https://img.shields.io/nuget/v/Stocks.Data.Ef.svg?label=Ef)](https://www.nuget.org/packages/Stocks.Data.Ef/)
+[![NuGet (Ado)](https://img.shields.io/nuget/v/Stocks.Data.Ado.svg?label=Ado)](https://www.nuget.org/packages/Stocks.Data.Ado/)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=PFalkowski_StocksData&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=PFalkowski_StocksData)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://choosealicense.com/licenses/mit/)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/piotrfalkowski)
+
+A collection of .NET 8 libraries for working with stock market data (OHLCV format).
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `Stocks.Data.Model` | Domain model: `StockQuote`, `Company`, `TradingSimulationResult` |
+| `Stocks.Data.Infrastructure` | CSV import helpers, OnTheFlyStats aggregation |
+| `Stocks.Data.Ef` | EF Core repositories and Unit of Work for stock data |
+| `Stocks.Data.Ado` | SQL Server bulk-insert via `SqlBulkCopy` |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# StocksData
+﻿# StocksData
 
 [![CI](https://github.com/PFalkowski/StocksData/actions/workflows/ci.yml/badge.svg)](https://github.com/PFalkowski/StocksData/actions/workflows/ci.yml)
 [![NuGet (Model)](https://img.shields.io/nuget/v/Stocks.Data.Model.svg?label=Model)](https://www.nuget.org/packages/Stocks.Data.Model/)
@@ -10,6 +10,15 @@
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-yellow.svg)](https://www.buymeacoffee.com/piotrfalkowski)
 
 A collection of .NET 8 libraries for working with stock market data (OHLCV format).
+
+## Install
+
+```bash
+dotnet add package Stocks.Data.Model
+dotnet add package Stocks.Data.Infrastructure
+dotnet add package Stocks.Data.Ef
+dotnet add package Stocks.Data.Ado
+```
 
 ## Packages
 

--- a/Stocks.Data.Ado/Stocks.Data.Ado.csproj
+++ b/Stocks.Data.Ado/Stocks.Data.Ado.csproj
@@ -1,41 +1,39 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <Configurations>Debug;Release;Pack</Configurations>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <Authors>Piotr Falkowski</Authors>
-    <Company />
-    <Copyright>Piotr Falkowski © 2020</Copyright>
-    <PackageLicenseUrl></PackageLicenseUrl>
-    <Version>2.0.0</Version>
+    <Description>Bulk insert using SqlBulkCopy for StockQuotes in daily format.</Description>
+    <Copyright>Piotr Falkowski © 2026</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/PFalkowski/StocksData</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PFalkowski/StocksData</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>bulk-insert, stock-quote</PackageTags>
-    <PackageReleaseNotes>initial release</PackageReleaseNotes>
-    <Description>bulk insert using SqlBulkCopy for StockQuotes in daily format.</Description>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>2.1.0</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Pack|AnyCPU'">
-    <Optimize>true</Optimize>
-  </PropertyGroup>
-  
   <ItemGroup>
-    <PackageReference Include="LoggerLite" Version="3.1.0" />
+    <PackageReference Include="LoggerLite" Version="5.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-    <PackageReference Include="Stocks.Data.Infrastructure" Version="2.0.1" Condition="'$(Configuration)' == 'Pack'" />
-    <PackageReference Remove="Stocks.Data.Infrastructure" Version="2.0.1" Condition="'$(Configuration)' != 'Pack'" />
-    <PackageReference Include="Stocks.Data.Model" Version="2.0.0" Condition="'$(Configuration)' == 'Pack'" />
-    <PackageReference Remove="Stocks.Data.Model" Version="2.0.0" Condition="'$(Configuration)' != 'Pack'" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Remove="..\Stocks.Data.Infrastructure\Stocks.Data.Infrastructure.csproj" Condition="'$(Configuration)' == 'Pack'" />
     <ProjectReference Include="..\Stocks.Data.Common\Stocks.Data.Common.csproj" />
-    <ProjectReference Include="..\Stocks.Data.Model\Stocks.Data.Model.csproj" Condition="'$(Configuration)' != 'Pack'" />
-    <ProjectReference Remove="..\Stocks.Data.Model\Stocks.Data.Model.csproj" Condition="'$(Configuration)' == 'Pack'" />
+    <ProjectReference Include="..\Stocks.Data.Model\Stocks.Data.Model.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Stocks.Data.Common/Stocks.Data.Common.csproj
+++ b/Stocks.Data.Common/Stocks.Data.Common.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="19.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Stocks.Data.Ef/Stocks.Data.Ef.csproj
+++ b/Stocks.Data.Ef/Stocks.Data.Ef.csproj
@@ -1,37 +1,39 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Copyright>Piotr Falkowski © 2020</Copyright>
-    <PackageLicenseUrl></PackageLicenseUrl>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Authors>Piotr Falkowski</Authors>
+    <Description>Persistence layer for stocks using Entity Framework Core.</Description>
+    <Copyright>Piotr Falkowski © 2026</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/PFalkowski/StocksData</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PFalkowski/StocksData</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Stock, Data, EntityFrameworkCore, UnitOfWork, Repository</PackageTags>
-    <Description>Persistance layer for stocks using Entity Framework Core. .NET Standard 2.0</Description>
-    <PackageReleaseNotes>Change namespaces</PackageReleaseNotes>
-    <Authors>Piotr Falkowski</Authors>
-    <Version>3.0.0</Version>
-    <Configurations>Debug;Release;Pack</Configurations>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Pack|AnyCPU'">
-    <Optimize>true</Optimize>
+    <Version>3.1.0</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="StandardInterfaces" Version="3.1.0" />
-    <PackageReference Include="Stocks.Data.Model" Version="2.0.0" Condition="'$(Configuration)' == 'Pack'" />
-    <PackageReference Remove="Stocks.Data.Model" Version="2.0.0" Condition="'$(Configuration)' != 'Pack'" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Stocks.Data.Common\Stocks.Data.Common.csproj" />
-    <ProjectReference Include="..\Stocks.Data.Model\Stocks.Data.Model.csproj" Condition="'$(Configuration)' != 'Pack'" />
-    <ProjectReference Remove="..\Stocks.Data.Model\Stocks.Data.Model.csproj" Condition="'$(Configuration)' == 'Pack'" />
+    <ProjectReference Include="..\Stocks.Data.Model\Stocks.Data.Model.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj
+++ b/Stocks.Data.Infrastructure/Stocks.Data.Infrastructure.csproj
@@ -1,38 +1,40 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>Infrastracture for persistance of stock quotes in daily format (open, high, low, close) and import from CSV files in .NET Standard 2.1</Description>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Authors>Piotr Falkowski</Authors>
+    <Description>Infrastructure for persistence of stock quotes in daily format (open, high, low, close) and import from CSV files.</Description>
+    <Copyright>Piotr Falkowski © 2026</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/PFalkowski/StocksData</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PFalkowski/StocksData</RepositoryUrl>
-    <Copyright>Piotr Falkowski © 2020</Copyright>
-    <PackageLicenseUrl></PackageLicenseUrl>
-    <PackageTags>Stock, Data, Csv</PackageTags>
-    <PackageReleaseNotes>fix bugs</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
-    <Authors>Piotr Falkowski</Authors>
-    <Version>3.0.0</Version>
-    <Configurations>Debug;Release;Pack</Configurations>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Pack|AnyCPU'">
-    <Optimize>true</Optimize>
+    <PackageTags>Stock, Data, Csv</PackageTags>
+    <Version>3.1.0</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="19.0.0" />
-    <PackageReference Include="Extensions.Standard" Version="4.0.0" />
+    <PackageReference Include="Extensions.Standard" Version="12.0.0" />
     <PackageReference Include="OnTheFlyStats" Version="3.2.0" />
     <PackageReference Include="StandardInterfaces" Version="3.1.0" />
-    <PackageReference Include="Stocks.Data.Model" Version="2.0.0" Condition="'$(Configuration)' == 'Pack'" />
-    <PackageReference Remove="Stocks.Data.Model" Version="2.0.0" Condition="'$(Configuration)' != 'Pack'" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Stocks.Data.Model\Stocks.Data.Model.csproj" Condition="'$(Configuration)' != 'Pack'" />
-    <ProjectReference Remove="..\Stocks.Data.Model\Stocks.Data.Model.csproj" Condition="'$(Configuration)' == 'Pack'" />
+    <ProjectReference Include="..\Stocks.Data.Model\Stocks.Data.Model.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Stocks.Data.Model/Stocks.Data.Model.csproj
+++ b/Stocks.Data.Model/Stocks.Data.Model.csproj
@@ -1,29 +1,34 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>Model for persistance of stock quotes in daily format (open, high, low, close) .NET Standard 2.0</Description>
-    <Copyright>Piotr Falkowski © 2020</Copyright>
-    <PackageLicenseUrl></PackageLicenseUrl>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Authors>Piotr Falkowski</Authors>
+    <Description>Model for persistence of stock quotes in daily format (open, high, low, close).</Description>
+    <Copyright>Piotr Falkowski © 2026</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/PFalkowski/StocksData</PackageProjectUrl>
     <RepositoryUrl>https://github.com/PFalkowski/StocksData</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Stocks, Data, Model, EntityFrameworkCore</PackageTags>
-    <PackageReleaseNotes>fix bugs</PackageReleaseNotes>
-    <Authors>Piotr Falkowski</Authors>
-    <Configurations>Debug;Release;Pack</Configurations>
-    <Version>3.0.0</Version>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Pack|AnyCPU'">
-    <Optimize>true</Optimize>
+    <Version>3.1.0</Version>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Extensions.Standard" Version="6.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="Extensions.Standard" Version="12.0.0" />
+    <PackageReference Include="StandardInterfaces" Version="3.1.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Stocks.Data.UnitTests.Ef/StockContextTest.cs
+++ b/Stocks.Data.UnitTests.Ef/StockContextTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollector.InProcDataCollector;
 using Stocks.Data.UnitTests.Ef.Test.TestData;
 using Stocks.Data.Model;
 using Xunit;

--- a/Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj
+++ b/Stocks.Data.UnitTests.Ef/Stocks.Data.UnitTests.Ef.csproj
@@ -1,40 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
-
     <AssemblyName>Stocks.Data.UnitTests.Ef.Test</AssemblyName>
-
     <RootNamespace>Stocks.Data.UnitTests.Ef.Test</RootNamespace>
-
-    <Configurations>Debug;Release;Pack</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Extensions.Serialization.Csv" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="StandardInterfaces" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Stocks.Data.Ef\Stocks.Data.Ef.csproj" />
     <ProjectReference Include="..\Stocks.Data.Model\Stocks.Data.Model.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System">
-      <HintPath>System</HintPath>
-    </Reference>
   </ItemGroup>
 
   <ItemGroup>
@@ -51,7 +43,5 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
-  <ProjectExtensions><VisualStudio><UserProperties /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/Stocks.Data.UnitTests.Infrastructure/Stocks.Data.UnitTests.Common.csproj
+++ b/Stocks.Data.UnitTests.Infrastructure/Stocks.Data.UnitTests.Common.csproj
@@ -1,24 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
-
     <AssemblyName>Stocks.Data.Common.Test</AssemblyName>
-
-    <Configurations>Debug;Release;Pack</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Extensions.Standard" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Extensions.Standard" Version="12.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Stocks.Data.UnitTests.Model/Stocks.Data.UnitTests.Model.csproj
+++ b/Stocks.Data.UnitTests.Model/Stocks.Data.UnitTests.Model.csproj
@@ -1,25 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
-
     <AssemblyName>Stocks.Data.UnitTests.Model</AssemblyName>
-
     <RootNamespace>Stocks.Data.UnitTests.Model</RootNamespace>
-
-    <Configurations>Debug;Release;Pack</Configurations>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- All 4 packages (Model, Infrastructure, Ef, Ado) + Common: netstandard2.1 -> net8.0
- EF Core 5.0.3 -> 8.0.0 (Common + Ef test packages)
- LoggerLite 3.1.0 -> 5.0.0 in Ado (ILogger interface unchanged since 3.x)
- Extensions.Standard 4.0.0/6.0.0 -> 12.0.0 in Model/Infrastructure/UnitTests.Infrastructure
- Remove System.ComponentModel.Annotations (built into net8.0)
- Simplify conditional Pack configuration (dotnet pack handles project->package ref automatically)
- SourceLink 8.0.0, GenerateDocumentationFile, PackageReadmeFile; version bumps
- Update test packages: xunit 2.9.3, runner 3.0.1, TestSdk 17.12.0, add coverlet; remove obsolete DotNetCliToolReference
- Remove stale using in StockContextTest.cs
- Add ci.yml, publish.yml (NuGet Trusted Publishing), sonar.yml workflows
- Update README with badges for all 4 packages

## Test plan
- [x] dotnet build all 4 packages -- 0 warnings, 0 errors
- [x] dotnet test UnitTests.Model -- 19/19 passed
- [x] dotnet test UnitTests.Infrastructure -- 4/4 passed
- [x] dotnet test UnitTests.Ef -- 49/49 passed (EF Core InMemory)

Generated with Claude Code